### PR TITLE
Rebuild cross-platform wheel workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,353 +1,99 @@
-name: Release Wheels
+name: Release wheels
 
 on:
   push:
-    tags:
-      - "v*"
+    tags: ["v*"]
   workflow_dispatch:
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
-env:
-  CIBW_BUILD: "cp310-* cp311-* cp312-*"
-  CIBW_SKIP: "pp* *-musllinux_*"
-  CIBW_TEST_COMMAND: 'python -c "import turboxl; print(turboxl.read_sheet_to_csv)"'
-  ZLIB_NG_VERSION: "2.3.3"
-  MINIZIP_NG_VERSION: "4.1.0"
+permissions:
+  contents: read
 
 jobs:
-  build-core-linux:
-    name: linux-x86_64 (core)
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Check out source
-        uses: actions/checkout@v4
-
-      - name: Set up Python (runner)
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-          cache: pip
-          cache-dependency-path: pyproject.toml
-
-      - name: Cache Linux deps
-        uses: actions/cache@v4
-        with:
-          path: ${{ runner.temp }}/cibw-deps/x86_64
-          key: linux-deps-x86_64-v2-${{ env.ZLIB_NG_VERSION }}-${{ env.MINIZIP_NG_VERSION }}-${{ hashFiles('.github/workflows/release.yml') }}
-          restore-keys: |
-            linux-deps-x86_64-v2-${{ env.ZLIB_NG_VERSION }}-${{ env.MINIZIP_NG_VERSION }}-
-            linux-deps-x86_64-v2-
-
-      - name: Cache Linux ccache
-        uses: actions/cache@v4
-        with:
-          path: ${{ runner.temp }}/cibw-ccache/x86_64
-          key: linux-ccache-x86_64-v2-${{ hashFiles('CMakeLists.txt', 'src/**', 'include/**', 'pyproject.toml') }}
-          restore-keys: |
-            linux-ccache-x86_64-v2-
-
-      - name: Install cibuildwheel
-        run: python -m pip install -U pip cibuildwheel
-
-      - name: Build Linux wheels
-        env:
-          CIBW_ARCHS_LINUX: x86_64
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-          CIBW_CONTAINER_ENGINE_OPTIONS: >-
-            -v ${{ runner.temp }}/cibw-deps/x86_64:/opt/deps
-            -v ${{ runner.temp }}/cibw-ccache/x86_64:/opt/ccache
-          CIBW_ENVIRONMENT_LINUX: >-
-            CMAKE_BUILD_PARALLEL_LEVEL=4
-            CCACHE_DIR=/opt/ccache
-            CCACHE_MAXSIZE=3G
-            CCACHE_BASEDIR=/project
-            CCACHE_COMPILERCHECK=content
-            CMAKE_C_COMPILER_LAUNCHER=ccache
-            CMAKE_CXX_COMPILER_LAUNCHER=ccache
-            ZLIB_NG_VERSION=${{ env.ZLIB_NG_VERSION }}
-            MINIZIP_NG_VERSION=${{ env.MINIZIP_NG_VERSION }}
-            PKG_CONFIG_PATH=/opt/deps/lib/pkgconfig:/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig
-            LD_LIBRARY_PATH=/opt/deps/lib:/usr/local/lib:/usr/local/lib64:$LD_LIBRARY_PATH
-            CMAKE_PREFIX_PATH=/opt/deps:/usr/local
-            ZLIB_ROOT=/opt/deps
-            minizip_DIR=/opt/deps/lib/cmake/minizip
-            CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Release -DTURBOXL_PORTABLE_BUILD=ON -DTURBOXL_ENABLE_NATIVE_OPTIMIZATION=OFF -DTURBOXL_ENABLE_IPO=ON -DMINIZIP_LIBRARY=/opt/deps/lib/libminizip.a -DMINIZIP_INCLUDE_DIR=/opt/deps/include/minizip"
-          CIBW_BEFORE_ALL_LINUX: |
-            set -eux
-            if [ -f /opt/deps/.zlib-ng-version ] && \
-               [ -f /opt/deps/.minizip-ng-version ] && \
-               [ "$(cat /opt/deps/.zlib-ng-version)" = "${ZLIB_NG_VERSION}" ] && \
-               [ "$(cat /opt/deps/.minizip-ng-version)" = "${MINIZIP_NG_VERSION}" ] && \
-               [ -f /opt/deps/lib/libz.a ] && \
-               [ -f /opt/deps/lib/libminizip.a ] && \
-               [ -f /opt/deps/lib/pkgconfig/minizip.pc ]; then
-              echo "Using cached /opt/deps"
-              exit 0
-            fi
-            rm -rf /opt/deps/*
-            mkdir -p /opt/deps/lib/pkgconfig
-            yum install -y gcc gcc-c++ make pkgconfig libxml2-devel curl tar ccache
-            python -m pip install --upgrade pip cmake ninja
-            rm -rf /tmp/zlib-ng /tmp/build-zlib /tmp/minizip-ng /tmp/build-minizip
-            curl -fsSL "https://github.com/zlib-ng/zlib-ng/archive/refs/tags/${ZLIB_NG_VERSION}.tar.gz" \
-              | tar -xz -C /tmp
-            mv "/tmp/zlib-ng-${ZLIB_NG_VERSION}" /tmp/zlib-ng
-            curl -fsSL "https://github.com/zlib-ng/minizip-ng/archive/refs/tags/${MINIZIP_NG_VERSION}.tar.gz" \
-              | tar -xz -C /tmp
-            mv "/tmp/minizip-ng-${MINIZIP_NG_VERSION}" /tmp/minizip-ng
-            cmake -S /tmp/zlib-ng -B /tmp/build-zlib -G Ninja \
-                  -DZLIB_COMPAT=ON \
-                  -DBUILD_SHARED_LIBS=OFF \
-                  -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-                  -DCMAKE_INSTALL_LIBDIR=lib \
-                  -DCMAKE_INSTALL_PREFIX=/opt/deps
-            cmake --build /tmp/build-zlib --target install --config Release
-
-            cmake -S /tmp/minizip-ng -B /tmp/build-minizip -G Ninja \
-                  -DMZ_ZLIB=ON \
-                  -DMZ_OPENSSL=OFF \
-                  -DMZ_BZIP2=OFF \
-                  -DMZ_LZMA=OFF \
-                  -DMZ_PPMD=OFF \
-                  -DMZ_ZSTD=OFF \
-                  -DMZ_LIBBSD=OFF \
-                  -DMZ_COMPAT=ON \
-                  -DBUILD_SHARED_LIBS=OFF \
-                  -DZLIB_ROOT=/opt/deps \
-                  -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-                  -DCMAKE_INSTALL_LIBDIR=lib \
-                  -DCMAKE_INSTALL_PREFIX=/opt/deps
-            cmake --build /tmp/build-minizip --target install --config Release
-            if nm -g /opt/deps/lib/libminizip.a | grep -q "Ppmd8_Construct"; then
-              echo "minizip archive unexpectedly references Ppmd8_Construct"
-              exit 1
-            fi
-
-            if [ -d /opt/deps/include/minizip ] && [ ! -e /opt/deps/include/minizip-ng ]; then
-              ln -s /opt/deps/include/minizip /opt/deps/include/minizip-ng
-            fi
-
-            mkdir -p /opt/deps/lib/pkgconfig
-            MINIZIP_VERSION=$(/usr/bin/env bash -c 'grep -E "^\#define MZ_VERSION " /tmp/minizip-ng/mz.h | sed -E "s/.*\"(.*)\".*/\1/"' || echo "unknown")
-            {
-              printf '%s\n' 'prefix=/opt/deps'
-              printf '%s\n' 'exec_prefix=${prefix}'
-              printf '%s\n' 'libdir=${prefix}/lib'
-              printf '%s\n' 'includedir=${prefix}/include'
-              printf '%s\n' ''
-              printf '%s\n' 'Name: minizip'
-              printf '%s\n' 'Description: Minizip-ng zip manipulation library'
-              printf 'Version: %s\n' "$MINIZIP_VERSION"
-              printf '%s\n' 'Libs: ${libdir}/libminizip.a'
-              printf '%s\n' 'Libs.private: -lz'
-              printf '%s\n' 'Cflags: -I${includedir}'
-            } > /opt/deps/lib/pkgconfig/minizip.pc
-            cp /opt/deps/lib/pkgconfig/minizip.pc /opt/deps/lib/pkgconfig/minizip-ng.pc
-            printf '%s\n' "${ZLIB_NG_VERSION}" > /opt/deps/.zlib-ng-version
-            printf '%s\n' "${MINIZIP_NG_VERSION}" > /opt/deps/.minizip-ng-version
-        run: python -m cibuildwheel --output-dir wheelhouse
-
-      - name: Upload Linux wheel artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels-linux-x86_64
-          path: wheelhouse/*.whl
-
-  build-windows-x64:
-    name: windows-x64 (long-tail)
-    runs-on: windows-latest
-    env:
-      VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}\\vcpkg-binary-cache,readwrite
-      VCPKG_BUILD_TYPE: release
-    steps:
-      - name: Check out source
-        uses: actions/checkout@v4
-
-      - name: Set up Python (runner)
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-          architecture: x64
-          cache: pip
-          cache-dependency-path: pyproject.toml
-
-      - name: Cache vcpkg binary artifacts
-        uses: actions/cache@v4
-        with:
-          path: ${{ github.workspace }}\vcpkg-binary-cache
-          key: windows-vcpkg-bin-x64-${{ hashFiles('vcpkg.json') }}
-          restore-keys: |
-            windows-vcpkg-bin-x64-
-
-      - name: Set up vcpkg
-        uses: lukka/run-vcpkg@v11
-        with:
-          runVcpkgInstall: false
-
-      - name: Normalize vcpkg path for CMake
-        shell: pwsh
-        run: |
-          $vcpkgRootForward = $env:VCPKG_ROOT -replace '\\', '/'
-          "VCPKG_ROOT_FWD=$vcpkgRootForward" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-
-      - name: Set cibuildwheel cache path
-        shell: pwsh
-        run: |
-          $cibwCacheDir = Join-Path $env:LOCALAPPDATA "pypa\cibuildwheel\Cache"
-          "CIBW_CACHE_DIR=$cibwCacheDir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-
-      - name: Cache cibuildwheel artifacts
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.CIBW_CACHE_DIR }}
-          key: windows-cibw-cache-x64-v1-${{ env.CIBW_BUILD }}-${{ hashFiles('pyproject.toml', '.github/workflows/release.yml') }}
-          restore-keys: |
-            windows-cibw-cache-x64-v1-${{ env.CIBW_BUILD }}-
-            windows-cibw-cache-x64-v1-
-
-      - name: Set Windows parallel build level
-        shell: pwsh
-        run: |
-          "CMAKE_BUILD_PARALLEL_LEVEL_WINDOWS=$env:NUMBER_OF_PROCESSORS" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-
-      - name: Install vcpkg dependencies (x64-windows-static)
-        run: |
-          & "$env:VCPKG_ROOT\vcpkg.exe" install `
-            --triplet x64-windows-static `
-            --clean-after-build
-
-      - name: Install cibuildwheel
-        run: python -m pip install -U pip cibuildwheel
-
-      - name: Build Windows wheels
-        env:
-          CIBW_ARCHS_WINDOWS: AMD64
-          CIBW_ENVIRONMENT_WINDOWS: >-
-            CMAKE_BUILD_PARALLEL_LEVEL=${{ env.CMAKE_BUILD_PARALLEL_LEVEL_WINDOWS }}
-            VCPKG_DEFAULT_TRIPLET=x64-windows-static
-            VCPKG_BUILD_TYPE=release
-            CMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_ROOT_FWD }}/scripts/buildsystems/vcpkg.cmake
-            CMAKE_FIND_PACKAGE_PREFER_CONFIG=ON
-            CMAKE_ARGS="-DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_ROOT_FWD }}/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows-static -DVCPKG_BUILD_TYPE=release -DCMAKE_BUILD_TYPE=Release -DCMAKE_FIND_PACKAGE_PREFER_CONFIG=ON"
-          CIBW_CACHE_PATH: ${{ env.CIBW_CACHE_DIR }}
-        run: python -m cibuildwheel --output-dir wheelhouse
-
-      - name: Upload Windows wheel artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels-windows-x64
-          path: wheelhouse/*.whl
-
-  build-macos-arm64:
-    name: macos-arm64 (long-tail)
-    runs-on: macos-15
-    steps:
-      - name: Check out source
-        uses: actions/checkout@v4
-
-      - name: Set up Python (runner)
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-          cache: pip
-          cache-dependency-path: pyproject.toml
-
-      - name: Install macOS dependencies
-        run: |
-          brew update
-          brew install cmake libxml2 minizip-ng zlib-ng pybind11
-
-      - name: Install cibuildwheel
-        run: python -m pip install -U pip cibuildwheel
-
-      - name: Build macOS arm64 wheels
-        env:
-          CIBW_ARCHS_MACOS: arm64
-          CIBW_ENVIRONMENT_MACOS: >-
-            CMAKE_BUILD_PARALLEL_LEVEL=4
-            MACOSX_DEPLOYMENT_TARGET=15.0
-        run: python -m cibuildwheel --output-dir wheelhouse
-
-      - name: Upload macOS arm64 wheel artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels-macos-arm64
-          path: wheelhouse/*.whl
-
-  build-macos-x86_64:
-    name: macos-x86_64 (long-tail)
-    runs-on: macos-15-intel
-    steps:
-      - name: Check out source
-        uses: actions/checkout@v4
-
-      - name: Set up Python (runner)
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-          cache: pip
-          cache-dependency-path: pyproject.toml
-
-      - name: Install macOS dependencies
-        run: |
-          brew update
-          brew install cmake libxml2 minizip-ng zlib-ng pybind11
-
-      - name: Install cibuildwheel
-        run: python -m pip install -U pip cibuildwheel
-
-      - name: Build macOS x86_64 wheels
-        env:
-          CIBW_ARCHS_MACOS: x86_64
-          CIBW_ENVIRONMENT_MACOS: >-
-            CMAKE_BUILD_PARALLEL_LEVEL=4
-            MACOSX_DEPLOYMENT_TARGET=15.0
-        run: python -m cibuildwheel --output-dir wheelhouse
-
-      - name: Upload macOS x86_64 wheel artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels-macos-x86_64
-          path: wheelhouse/*.whl
+  wheels:
+    name: ${{ matrix.name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux x86_64
+            runner: ubuntu-24.04
+            arch: x86_64
+            build: "cp310-manylinux_x86_64 cp311-manylinux_x86_64 cp312-manylinux_x86_64"
+            bits: 64
+            artifact: wheels-linux-x86_64
+            vcpkg-triplet: ""
+          - name: Windows x64
+            runner: windows-2022
+            arch: AMD64
+            build: "cp310-win_amd64 cp311-win_amd64 cp312-win_amd64"
+            bits: 64
+            artifact: wheels-windows-x64
+            vcpkg-triplet: x64-windows-static-md
+          - name: Windows x86
+            runner: windows-2022
+            arch: x86
+            build: "cp310-win32 cp311-win32 cp312-win32"
+            bits: 32
+            artifact: wheels-windows-x86
+            vcpkg-triplet: x86-windows-static-md
+          - name: macOS arm64
+            runner: macos-15
+            arch: arm64
+            build: "cp310-macosx_arm64 cp311-macosx_arm64 cp312-macosx_arm64"
+            bits: 64
+            artifact: wheels-macos-arm64
+            vcpkg-triplet: ""
+          - name: macOS x86_64
+            runner: macos-15-intel
+            arch: x86_64
+            build: "cp310-macosx_x86_64 cp311-macosx_x86_64 cp312-macosx_x86_64"
+            bits: 64
+            artifact: wheels-macos-x86_64
+            vcpkg-triplet: ""
+    uses: ./.github/workflows/wheel.yml
+    with:
+      runner: ${{ matrix.runner }}
+      arch: ${{ matrix.arch }}
+      build: ${{ matrix.build }}
+      expected-bits: ${{ matrix.bits }}
+      artifact-name: ${{ matrix.artifact }}
+      vcpkg-triplet: ${{ matrix.vcpkg-triplet }}
 
   publish:
     name: Publish to PyPI
-    needs: [build-core-linux, build-windows-x64, build-macos-arm64, build-macos-x86_64]
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: wheels
     runs-on: ubuntu-latest
     steps:
-      - name: Download all wheel artifacts
+      - name: Download wheels
         uses: actions/download-artifact@v4
         with:
           path: dist
           merge-multiple: true
-
-      - name: Publish package to PyPI
+      - name: Publish package
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
 
   release-assets:
-    name: Upload GitHub release assets
+    name: Add wheels to GitHub release
+    if: startsWith(github.ref, 'refs/tags/v')
     needs: publish
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      - name: Download built wheels
+      - name: Download wheels
         uses: actions/download-artifact@v4
         with:
           path: dist
           merge-multiple: true
-
-      - name: Upload wheels to GitHub Release
+      - name: Upload release assets
         uses: softprops/action-gh-release@v2
         with:
-          files: dist/*
-          tag_name: ${{ github.ref_name }}
-          name: ${{ github.ref_name }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          files: dist/*.whl

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,4 +1,4 @@
-name: Verify Wheels
+name: Verify wheels
 
 on:
   pull_request:
@@ -7,379 +7,68 @@ on:
       - "**.md"
       - "**.rst"
       - "docs/**"
-      - ".github/ISSUE_TEMPLATE/**"
   push:
     branches: [main]
     paths-ignore:
       - "**.md"
       - "**.rst"
       - "docs/**"
-      - ".github/ISSUE_TEMPLATE/**"
   workflow_dispatch:
 
 concurrency:
-  group: verify-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
-env:
-  CIBW_BUILD: "cp312-*"
-  CIBW_SKIP: "pp* *-musllinux_*"
-  CIBW_TEST_COMMAND: 'python -c "import turboxl; print(turboxl.read_sheet_to_csv)"'
-  ZLIB_NG_VERSION: "2.3.3"
-  MINIZIP_NG_VERSION: "4.1.0"
+permissions:
+  contents: read
 
 jobs:
-  verify-linux-fast:
-    name: verify-linux-fast-x86_64
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Check out source
-        uses: actions/checkout@v4
-
-      - name: Set up Python (runner)
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-          cache: pip
-          cache-dependency-path: pyproject.toml
-
-      - name: Cache Linux deps
-        uses: actions/cache@v4
-        with:
-          path: ${{ runner.temp }}/cibw-deps/x86_64
-          key: verify-linux-deps-x86_64-v2-${{ env.ZLIB_NG_VERSION }}-${{ env.MINIZIP_NG_VERSION }}-${{ hashFiles('.github/workflows/verify.yml') }}
-          restore-keys: |
-            verify-linux-deps-x86_64-v2-${{ env.ZLIB_NG_VERSION }}-${{ env.MINIZIP_NG_VERSION }}-
-            verify-linux-deps-x86_64-v2-
-
-      - name: Cache Linux ccache
-        uses: actions/cache@v4
-        with:
-          path: ${{ runner.temp }}/cibw-ccache/x86_64
-          key: verify-linux-fast-ccache-x86_64-v2-${{ hashFiles('CMakeLists.txt', 'src/**', 'include/**', 'pyproject.toml') }}
-          restore-keys: |
-            verify-linux-fast-ccache-x86_64-v2-
-            verify-linux-ccache-x86_64-v2-
-
-      - name: Install cibuildwheel
-        run: python -m pip install -U pip cibuildwheel
-
-      - name: Build verify Linux fast wheel
-        env:
-          CIBW_ARCHS_LINUX: x86_64
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-          CIBW_BUILD: "cp312-manylinux_x86_64"
-          CIBW_CONTAINER_ENGINE_OPTIONS: >-
-            -v ${{ runner.temp }}/cibw-deps/x86_64:/opt/deps
-            -v ${{ runner.temp }}/cibw-ccache/x86_64:/opt/ccache
-          CIBW_ENVIRONMENT_LINUX: >-
-            CMAKE_BUILD_PARALLEL_LEVEL=4
-            CCACHE_DIR=/opt/ccache
-            CCACHE_MAXSIZE=3G
-            CCACHE_BASEDIR=/project
-            CCACHE_COMPILERCHECK=content
-            CMAKE_C_COMPILER_LAUNCHER=ccache
-            CMAKE_CXX_COMPILER_LAUNCHER=ccache
-            ZLIB_NG_VERSION=${{ env.ZLIB_NG_VERSION }}
-            MINIZIP_NG_VERSION=${{ env.MINIZIP_NG_VERSION }}
-            PKG_CONFIG_PATH=/opt/deps/lib/pkgconfig:/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig
-            LD_LIBRARY_PATH=/opt/deps/lib:/usr/local/lib:/usr/local/lib64:$LD_LIBRARY_PATH
-            CMAKE_PREFIX_PATH=/opt/deps:/usr/local
-            ZLIB_ROOT=/opt/deps
-            minizip_DIR=/opt/deps/lib/cmake/minizip
-            CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Release -DTURBOXL_PORTABLE_BUILD=ON -DTURBOXL_CI_FAST_BUILD=ON -DTURBOXL_ENABLE_IPO=OFF -DTURBOXL_ENABLE_NATIVE_OPTIMIZATION=OFF -DMINIZIP_LIBRARY=/opt/deps/lib/libminizip.a -DMINIZIP_INCLUDE_DIR=/opt/deps/include/minizip"
-          CIBW_BEFORE_ALL_LINUX: |
-            set -eux
-            if [ -f /opt/deps/.zlib-ng-version ] && \
-               [ -f /opt/deps/.minizip-ng-version ] && \
-               [ "$(cat /opt/deps/.zlib-ng-version)" = "${ZLIB_NG_VERSION}" ] && \
-               [ "$(cat /opt/deps/.minizip-ng-version)" = "${MINIZIP_NG_VERSION}" ] && \
-               [ -f /opt/deps/lib/libz.a ] && \
-               [ -f /opt/deps/lib/libminizip.a ] && \
-               [ -f /opt/deps/lib/pkgconfig/minizip.pc ]; then
-              echo "Using cached /opt/deps"
-              exit 0
-            fi
-            rm -rf /opt/deps/*
-            mkdir -p /opt/deps/lib/pkgconfig
-            yum install -y gcc gcc-c++ make pkgconfig libxml2-devel curl tar ccache
-            python -m pip install --upgrade pip cmake ninja
-            rm -rf /tmp/zlib-ng /tmp/build-zlib /tmp/minizip-ng /tmp/build-minizip
-            curl -fsSL "https://github.com/zlib-ng/zlib-ng/archive/refs/tags/${ZLIB_NG_VERSION}.tar.gz" \
-              | tar -xz -C /tmp
-            mv "/tmp/zlib-ng-${ZLIB_NG_VERSION}" /tmp/zlib-ng
-            curl -fsSL "https://github.com/zlib-ng/minizip-ng/archive/refs/tags/${MINIZIP_NG_VERSION}.tar.gz" \
-              | tar -xz -C /tmp
-            mv "/tmp/minizip-ng-${MINIZIP_NG_VERSION}" /tmp/minizip-ng
-            cmake -S /tmp/zlib-ng -B /tmp/build-zlib -G Ninja \
-                  -DZLIB_COMPAT=ON \
-                  -DBUILD_SHARED_LIBS=OFF \
-                  -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-                  -DCMAKE_INSTALL_LIBDIR=lib \
-                  -DCMAKE_INSTALL_PREFIX=/opt/deps
-            cmake --build /tmp/build-zlib --target install --config Release
-            cmake -S /tmp/minizip-ng -B /tmp/build-minizip -G Ninja \
-                  -DMZ_ZLIB=ON \
-                  -DMZ_OPENSSL=OFF \
-                  -DMZ_BZIP2=OFF \
-                  -DMZ_LZMA=OFF \
-                  -DMZ_PPMD=OFF \
-                  -DMZ_ZSTD=OFF \
-                  -DMZ_LIBBSD=OFF \
-                  -DMZ_COMPAT=ON \
-                  -DBUILD_SHARED_LIBS=OFF \
-                  -DZLIB_ROOT=/opt/deps \
-                  -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-                  -DCMAKE_INSTALL_LIBDIR=lib \
-                  -DCMAKE_INSTALL_PREFIX=/opt/deps
-            cmake --build /tmp/build-minizip --target install --config Release
-            if [ -f /opt/deps/lib/pkgconfig/minizip.pc ] && \
-               [ -f /opt/deps/lib/pkgconfig/minizip-ng.pc ] && \
-               [ -f /opt/deps/include/libxml2/libxml/parser.h ] && \
-               [ -f /opt/deps/lib/libminizip.a ] && \
-               nm -g /opt/deps/lib/libminizip.a | grep -q " unzReadCurrentFile$" && \
-               ! nm -g /opt/deps/lib/libminizip.a | grep -q "Ppmd8_Construct"; then
-              :
-            fi
-            if nm -g /opt/deps/lib/libminizip.a | grep -q "Ppmd8_Construct"; then
-              echo "minizip archive unexpectedly references Ppmd8_Construct"
-              exit 1
-            fi
-            if [ -d /opt/deps/include/minizip ] && [ ! -e /opt/deps/include/minizip-ng ]; then
-              ln -s /opt/deps/include/minizip /opt/deps/include/minizip-ng
-            fi
-            mkdir -p /opt/deps/lib/pkgconfig
-            MINIZIP_VERSION=$(/usr/bin/env bash -c 'grep -E "^\#define MZ_VERSION " /tmp/minizip-ng/mz.h | sed -E "s/.*\"(.*)\".*/\1/"' || echo "unknown")
-            {
-              printf '%s\n' 'prefix=/opt/deps'
-              printf '%s\n' 'exec_prefix=${prefix}'
-              printf '%s\n' 'libdir=${prefix}/lib'
-              printf '%s\n' 'includedir=${prefix}/include'
-              printf '%s\n' ''
-              printf '%s\n' 'Name: minizip'
-              printf '%s\n' 'Description: Minizip-ng zip manipulation library'
-              printf 'Version: %s\n' "$MINIZIP_VERSION"
-              printf '%s\n' 'Libs: ${libdir}/libminizip.a'
-              printf '%s\n' 'Libs.private: -lz'
-              printf '%s\n' 'Cflags: -I${includedir}'
-            } > /opt/deps/lib/pkgconfig/minizip.pc
-            cp /opt/deps/lib/pkgconfig/minizip.pc /opt/deps/lib/pkgconfig/minizip-ng.pc
-            printf '%s\n' "${ZLIB_NG_VERSION}" > /opt/deps/.zlib-ng-version
-            printf '%s\n' "${MINIZIP_NG_VERSION}" > /opt/deps/.minizip-ng-version
-        run: python -m cibuildwheel --output-dir wheelhouse
-
-  verify-linux-full:
-    name: verify-linux-full-x86_64
-    if: github.event_name != 'pull_request'
-    needs: verify-linux-fast
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Check out source
-        uses: actions/checkout@v4
-
-      - name: Set up Python (runner)
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-          cache: pip
-          cache-dependency-path: pyproject.toml
-
-      - name: Cache Linux deps
-        uses: actions/cache@v4
-        with:
-          path: ${{ runner.temp }}/cibw-deps/x86_64
-          key: verify-linux-deps-x86_64-v2-${{ env.ZLIB_NG_VERSION }}-${{ env.MINIZIP_NG_VERSION }}-${{ hashFiles('.github/workflows/verify.yml') }}
-          restore-keys: |
-            verify-linux-deps-x86_64-v2-${{ env.ZLIB_NG_VERSION }}-${{ env.MINIZIP_NG_VERSION }}-
-            verify-linux-deps-x86_64-v2-
-
-      - name: Cache Linux ccache
-        uses: actions/cache@v4
-        with:
-          path: ${{ runner.temp }}/cibw-ccache/x86_64
-          key: verify-linux-ccache-x86_64-v2-${{ hashFiles('CMakeLists.txt', 'src/**', 'include/**', 'pyproject.toml') }}
-          restore-keys: |
-            verify-linux-ccache-x86_64-v2-
-
-      - name: Install cibuildwheel
-        run: python -m pip install -U pip cibuildwheel
-
-      - name: Build verify Linux full wheels
-        env:
-          CIBW_ARCHS_LINUX: x86_64
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-          CIBW_CONTAINER_ENGINE_OPTIONS: >-
-            -v ${{ runner.temp }}/cibw-deps/x86_64:/opt/deps
-            -v ${{ runner.temp }}/cibw-ccache/x86_64:/opt/ccache
-          CIBW_ENVIRONMENT_LINUX: >-
-            CMAKE_BUILD_PARALLEL_LEVEL=4
-            CCACHE_DIR=/opt/ccache
-            CCACHE_MAXSIZE=3G
-            CCACHE_BASEDIR=/project
-            CCACHE_COMPILERCHECK=content
-            CMAKE_C_COMPILER_LAUNCHER=ccache
-            CMAKE_CXX_COMPILER_LAUNCHER=ccache
-            ZLIB_NG_VERSION=${{ env.ZLIB_NG_VERSION }}
-            MINIZIP_NG_VERSION=${{ env.MINIZIP_NG_VERSION }}
-            PKG_CONFIG_PATH=/opt/deps/lib/pkgconfig:/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig
-            LD_LIBRARY_PATH=/opt/deps/lib:/usr/local/lib:/usr/local/lib64:$LD_LIBRARY_PATH
-            CMAKE_PREFIX_PATH=/opt/deps:/usr/local
-            ZLIB_ROOT=/opt/deps
-            minizip_DIR=/opt/deps/lib/cmake/minizip
-            CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Release -DTURBOXL_PORTABLE_BUILD=ON -DTURBOXL_ENABLE_NATIVE_OPTIMIZATION=OFF -DTURBOXL_ENABLE_IPO=ON -DMINIZIP_LIBRARY=/opt/deps/lib/libminizip.a -DMINIZIP_INCLUDE_DIR=/opt/deps/include/minizip"
-          CIBW_BEFORE_ALL_LINUX: |
-            set -eux
-            if [ -f /opt/deps/.zlib-ng-version ] && \
-               [ -f /opt/deps/.minizip-ng-version ] && \
-               [ "$(cat /opt/deps/.zlib-ng-version)" = "${ZLIB_NG_VERSION}" ] && \
-               [ "$(cat /opt/deps/.minizip-ng-version)" = "${MINIZIP_NG_VERSION}" ] && \
-               [ -f /opt/deps/lib/libz.a ] && \
-               [ -f /opt/deps/lib/libminizip.a ] && \
-               [ -f /opt/deps/lib/pkgconfig/minizip.pc ]; then
-              echo "Using cached /opt/deps"
-              exit 0
-            fi
-            rm -rf /opt/deps/*
-            mkdir -p /opt/deps/lib/pkgconfig
-            yum install -y gcc gcc-c++ make pkgconfig libxml2-devel curl tar ccache
-            python -m pip install --upgrade pip cmake ninja
-            rm -rf /tmp/zlib-ng /tmp/build-zlib /tmp/minizip-ng /tmp/build-minizip
-            curl -fsSL "https://github.com/zlib-ng/zlib-ng/archive/refs/tags/${ZLIB_NG_VERSION}.tar.gz" \
-              | tar -xz -C /tmp
-            mv "/tmp/zlib-ng-${ZLIB_NG_VERSION}" /tmp/zlib-ng
-            curl -fsSL "https://github.com/zlib-ng/minizip-ng/archive/refs/tags/${MINIZIP_NG_VERSION}.tar.gz" \
-              | tar -xz -C /tmp
-            mv "/tmp/minizip-ng-${MINIZIP_NG_VERSION}" /tmp/minizip-ng
-            cmake -S /tmp/zlib-ng -B /tmp/build-zlib -G Ninja \
-                  -DZLIB_COMPAT=ON \
-                  -DBUILD_SHARED_LIBS=OFF \
-                  -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-                  -DCMAKE_INSTALL_LIBDIR=lib \
-                  -DCMAKE_INSTALL_PREFIX=/opt/deps
-            cmake --build /tmp/build-zlib --target install --config Release
-            cmake -S /tmp/minizip-ng -B /tmp/build-minizip -G Ninja \
-                  -DMZ_ZLIB=ON \
-                  -DMZ_OPENSSL=OFF \
-                  -DMZ_BZIP2=OFF \
-                  -DMZ_LZMA=OFF \
-                  -DMZ_PPMD=OFF \
-                  -DMZ_ZSTD=OFF \
-                  -DMZ_LIBBSD=OFF \
-                  -DMZ_COMPAT=ON \
-                  -DBUILD_SHARED_LIBS=OFF \
-                  -DZLIB_ROOT=/opt/deps \
-                  -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-                  -DCMAKE_INSTALL_LIBDIR=lib \
-                  -DCMAKE_INSTALL_PREFIX=/opt/deps
-            cmake --build /tmp/build-minizip --target install --config Release
-            if nm -g /opt/deps/lib/libminizip.a | grep -q "Ppmd8_Construct"; then
-              echo "minizip archive unexpectedly references Ppmd8_Construct"
-              exit 1
-            fi
-            if [ -d /opt/deps/include/minizip ] && [ ! -e /opt/deps/include/minizip-ng ]; then
-              ln -s /opt/deps/include/minizip /opt/deps/include/minizip-ng
-            fi
-            MINIZIP_VERSION=$(/usr/bin/env bash -c 'grep -E "^\#define MZ_VERSION " /tmp/minizip-ng/mz.h | sed -E "s/.*\"(.*)\".*/\1/"' || echo "unknown")
-            {
-              printf '%s\n' 'prefix=/opt/deps'
-              printf '%s\n' 'exec_prefix=${prefix}'
-              printf '%s\n' 'libdir=${prefix}/lib'
-              printf '%s\n' 'includedir=${prefix}/include'
-              printf '%s\n' ''
-              printf '%s\n' 'Name: minizip'
-              printf '%s\n' 'Description: Minizip-ng zip manipulation library'
-              printf 'Version: %s\n' "$MINIZIP_VERSION"
-              printf '%s\n' 'Libs: ${libdir}/libminizip.a'
-              printf '%s\n' 'Libs.private: -lz'
-              printf '%s\n' 'Cflags: -I${includedir}'
-            } > /opt/deps/lib/pkgconfig/minizip.pc
-            cp /opt/deps/lib/pkgconfig/minizip.pc /opt/deps/lib/pkgconfig/minizip-ng.pc
-            printf '%s\n' "${ZLIB_NG_VERSION}" > /opt/deps/.zlib-ng-version
-            printf '%s\n' "${MINIZIP_NG_VERSION}" > /opt/deps/.minizip-ng-version
-        run: python -m cibuildwheel --output-dir wheelhouse
-
-  verify-windows:
-    name: verify-windows-x64
-    runs-on: windows-latest
-    env:
-      VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}\\vcpkg-binary-cache,readwrite
-    steps:
-      - name: Check out source
-        uses: actions/checkout@v4
-
-      - name: Set up Python (runner)
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-          architecture: x64
-          cache: pip
-          cache-dependency-path: pyproject.toml
-
-      - name: Cache vcpkg binary artifacts
-        uses: actions/cache@v4
-        with:
-          path: ${{ github.workspace }}\vcpkg-binary-cache
-          key: verify-windows-vcpkg-bin-x64-${{ hashFiles('vcpkg.json') }}
-          restore-keys: |
-            verify-windows-vcpkg-bin-x64-
-            windows-vcpkg-bin-x64-
-
-      - name: Set up vcpkg
-        uses: lukka/run-vcpkg@v11
-        with:
-          runVcpkgInstall: false
-
-      - name: Normalize vcpkg path for CMake
-        shell: pwsh
-        run: |
-          $vcpkgRootForward = $env:VCPKG_ROOT -replace '\\', '/'
-          "VCPKG_ROOT_FWD=$vcpkgRootForward" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-
-      - name: Install vcpkg dependencies (x64-windows-static)
-        run: |
-          & "$env:VCPKG_ROOT\vcpkg.exe" install `
-            --triplet x64-windows-static
-
-      - name: Install cibuildwheel
-        run: python -m pip install -U pip cibuildwheel
-
-      - name: Build verify Windows wheel
-        env:
-          CIBW_ARCHS_WINDOWS: AMD64
-          CIBW_ENVIRONMENT_WINDOWS: >-
-            CMAKE_BUILD_PARALLEL_LEVEL=4
-            VCPKG_DEFAULT_TRIPLET=x64-windows-static
-            CMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_ROOT_FWD }}/scripts/buildsystems/vcpkg.cmake
-            CMAKE_FIND_PACKAGE_PREFER_CONFIG=ON
-            CMAKE_ARGS="-DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_ROOT_FWD }}/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows-static -DCMAKE_FIND_PACKAGE_PREFER_CONFIG=ON"
-        run: python -m cibuildwheel --output-dir wheelhouse
-
-  verify-macos:
-    name: verify-macos-arm64
-    runs-on: macos-15
-    steps:
-      - name: Check out source
-        uses: actions/checkout@v4
-
-      - name: Set up Python (runner)
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-          cache: pip
-          cache-dependency-path: pyproject.toml
-
-      - name: Install macOS dependencies
-        run: |
-          brew update
-          brew install cmake libxml2 minizip-ng zlib-ng pybind11
-
-      - name: Install cibuildwheel
-        run: python -m pip install -U pip cibuildwheel
-
-      - name: Build verify macOS wheel
-        env:
-          CIBW_ARCHS_MACOS: arm64
-          CIBW_ENVIRONMENT_MACOS: >-
-            CMAKE_BUILD_PARALLEL_LEVEL=4
-            MACOSX_DEPLOYMENT_TARGET=15.0
-        run: python -m cibuildwheel --output-dir wheelhouse
+  wheels:
+    name: ${{ matrix.name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux x86_64
+            runner: ubuntu-24.04
+            arch: x86_64
+            build: cp312-manylinux_x86_64
+            bits: 64
+            artifact: verify-linux-x86_64
+            vcpkg-triplet: ""
+          - name: Windows x64
+            runner: windows-2022
+            arch: AMD64
+            build: cp312-win_amd64
+            bits: 64
+            artifact: verify-windows-x64
+            vcpkg-triplet: x64-windows-static-md
+          - name: Windows x86
+            runner: windows-2022
+            arch: x86
+            build: cp312-win32
+            bits: 32
+            artifact: verify-windows-x86
+            vcpkg-triplet: x86-windows-static-md
+          - name: macOS arm64
+            runner: macos-15
+            arch: arm64
+            build: cp312-macosx_arm64
+            bits: 64
+            artifact: verify-macos-arm64
+            vcpkg-triplet: ""
+          - name: macOS x86_64
+            runner: macos-15-intel
+            arch: x86_64
+            build: cp312-macosx_x86_64
+            bits: 64
+            artifact: verify-macos-x86_64
+            vcpkg-triplet: ""
+    uses: ./.github/workflows/wheel.yml
+    with:
+      runner: ${{ matrix.runner }}
+      arch: ${{ matrix.arch }}
+      build: ${{ matrix.build }}
+      expected-bits: ${{ matrix.bits }}
+      artifact-name: ${{ matrix.artifact }}
+      vcpkg-triplet: ${{ matrix.vcpkg-triplet }}

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -1,0 +1,102 @@
+name: Build wheel set
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        description: GitHub runner label
+        required: true
+        type: string
+      arch:
+        description: cibuildwheel architecture
+        required: true
+        type: string
+      build:
+        description: cibuildwheel build identifiers
+        required: true
+        type: string
+      expected-bits:
+        description: Pointer width asserted by the installed-wheel test
+        required: true
+        type: number
+      artifact-name:
+        description: Uploaded wheel artifact name
+        required: true
+        type: string
+      vcpkg-triplet:
+        description: Windows vcpkg triplet; empty on other platforms
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ${{ inputs.runner }}
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Activate 32-bit MSVC tools
+        if: runner.os == 'Windows' && inputs.arch == 'x86'
+        uses: bus1/cabuild/action/msdevshell@v1
+        with:
+          architecture: x86
+
+      - name: Cache Windows dependencies
+        if: runner.os == 'Windows'
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}\vcpkg-binary-cache
+          key: vcpkg-${{ runner.os }}-${{ inputs.vcpkg-triplet }}-${{ hashFiles('vcpkg.json', 'cmake/triplets/**') }}
+          restore-keys: vcpkg-${{ runner.os }}-${{ inputs.vcpkg-triplet }}-
+
+      - name: Set up vcpkg
+        if: runner.os == 'Windows'
+        uses: lukka/run-vcpkg@v11
+        with:
+          runVcpkgInstall: false
+
+      - name: Install Windows dependencies
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          VCPKG_BINARY_SOURCES: clear;files,${{ runner.temp }}\vcpkg-binary-cache,readwrite
+        run: |
+          & "$env:VCPKG_ROOT\vcpkg.exe" install `
+            --triplet "${{ inputs.vcpkg-triplet }}" `
+            --overlay-triplets "$env:GITHUB_WORKSPACE\cmake\triplets" `
+            --clean-after-build
+          $root = $env:VCPKG_ROOT.Replace('\', '/')
+          $triplets = "$env:GITHUB_WORKSPACE/cmake/triplets".Replace('\', '/')
+          "VCPKG_ROOT_FWD=$root" | Out-File $env:GITHUB_ENV -Encoding utf8 -Append
+          "VCPKG_TRIPLETS_FWD=$triplets" | Out-File $env:GITHUB_ENV -Encoding utf8 -Append
+          "BUILD_PARALLEL=$env:NUMBER_OF_PROCESSORS" | Out-File $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Build and test wheels
+        uses: pypa/cibuildwheel@v4.1.0
+        with:
+          extras: uv
+        env:
+          CIBW_ARCHS: ${{ inputs.arch }}
+          CIBW_BUILD: ${{ inputs.build }}
+          CIBW_BUILD_VERBOSITY: "1"
+          CIBW_TEST_COMMAND: python {project}/tools/wheels/smoke_test.py ${{ inputs.expected-bits }}
+          CIBW_ENVIRONMENT_WINDOWS: >-
+            CMAKE_BUILD_PARALLEL_LEVEL=${{ env.BUILD_PARALLEL }}
+            CMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_ROOT_FWD }}/scripts/buildsystems/vcpkg.cmake
+            VCPKG_DEFAULT_TRIPLET=${{ inputs.vcpkg-triplet }}
+            VCPKG_OVERLAY_TRIPLETS=${{ env.VCPKG_TRIPLETS_FWD }}
+            CMAKE_ARGS="-DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_ROOT_FWD }}/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=${{ inputs.vcpkg-triplet }} -DVCPKG_OVERLAY_TRIPLETS=${{ env.VCPKG_TRIPLETS_FWD }} -DTURBOXL_STATIC_WINDOWS_DEPS=ON -DTURBOXL_PORTABLE_BUILD=ON -DTURBOXL_ENABLE_NATIVE_OPTIMIZATION=OFF -DTURBOXL_ENABLE_IPO=ON"
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: wheelhouse/*.whl
+          if-no-files-found: error
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ Makefile
 *.cmake
 !CMakeLists.txt
 !cmake/*.cmake.in
+!cmake/triplets/
+!cmake/triplets/*.cmake
 
 # Compiler generated files
 *.o
@@ -56,6 +58,9 @@ parts/
 sdist/
 var/
 wheels/
+!tools/wheels/
+!tools/wheels/*.py
+!tools/wheels/*.sh
 *.egg-info/
 .installed.cfg
 *.egg

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ option(TURBOXL_PORTABLE_BUILD "Disable host-specific CPU tuning for portable bin
 option(TURBOXL_CI_FAST_BUILD "Reduce compile-time optimizations for faster CI builds" OFF)
 option(TURBOXL_ENABLE_NATIVE_OPTIMIZATION "Enable host-specific CPU optimization flags where safe" ON)
 option(TURBOXL_ENABLE_IPO "Enable interprocedural optimization (LTO) for Release builds" ON)
+option(TURBOXL_STATIC_WINDOWS_DEPS "Define static-library APIs for Windows dependencies" OFF)
 
 include(CheckIPOSupported)
 
@@ -151,8 +152,8 @@ else()
         set(_ZIP_READY ON)
     endif()
 
-    # Find minizip-ng (prefer CMake package target from /opt/deps install),
-    # then fall back to pkg-config.
+    # Find minizip-ng (prefer a CMake package target), then fall back to
+    # either the minizip-ng or distro-provided minizip pkg-config module.
     if(NOT _ZIP_READY)
         find_package(minizip CONFIG QUIET)
         find_package(minizip-ng CONFIG QUIET)
@@ -163,6 +164,9 @@ else()
             set(_ZIP_READY ON)
         else()
             pkg_check_modules(MINIZIP minizip-ng)
+            if(NOT MINIZIP_FOUND)
+                pkg_check_modules(MINIZIP minizip)
+            endif()
             if(MINIZIP_FOUND)
                 set(ZIP_LIBRARY "minizip-ng")
                 set(ZIP_INCLUDE_DIRS ${MINIZIP_INCLUDE_DIRS})
@@ -233,6 +237,9 @@ target_include_directories(turboxl_core
 # On Windows, when linking against a static libxml2, headers expect LIBXML_STATIC
 if(WIN32)
     set(_LIBXML2_IS_STATIC OFF)
+    if(TURBOXL_STATIC_WINDOWS_DEPS)
+        set(_LIBXML2_IS_STATIC ON)
+    endif()
     foreach(_lib ${LIBXML2_LIBRARIES})
         string(TOLOWER "${_lib}" _lib_lower)
         if(_lib_lower MATCHES "libxml2s\\.lib" OR _lib_lower MATCHES "libxml2\\.a")
@@ -317,6 +324,8 @@ endif()
 
 # Python bindings
 if(BUILD_PYTHON)
+    set(PYBIND11_FINDPYTHON ON)
+    find_package(Python COMPONENTS Interpreter Development.Module REQUIRED)
     find_package(pybind11 CONFIG REQUIRED)
     
     pybind11_add_module(turboxl src/python/module.cpp)

--- a/cmake/triplets/x86-windows-static-md.cmake
+++ b/cmake/triplets/x86-windows-static-md.cmake
@@ -1,0 +1,5 @@
+# Python extensions must use the same dynamic MSVC runtime as CPython, while
+# third-party libraries are static so the wheel has no extra DLLs to bundle.
+set(VCPKG_TARGET_ARCHITECTURE x86)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,42 @@ wheel.expand-macos-universal-tags = true
 cmake.build-type = "Release"
 cmake.define = { BUILD_PYTHON = "ON", BUILD_TESTS = "OFF", BUILD_CLI = "OFF", BUILD_BENCHMARKS = "OFF" }
 
+# Keep wheel policy here so local and CI builds use the same settings. The
+# workflows only choose the exact interpreter/platform identifiers to build.
+[tool.cibuildwheel]
+build = ["cp310-*", "cp311-*", "cp312-*"]
+skip = ["pp*", "*-musllinux_*"]
+build-frontend = "uv"
+test-command = "python {project}/tools/wheels/smoke_test.py"
+
+[tool.cibuildwheel.linux]
+manylinux-x86_64-image = "manylinux_2_28"
+before-all = "bash {package}/tools/wheels/install_linux_deps.sh"
+
+[tool.cibuildwheel.linux.environment]
+CMAKE_BUILD_PARALLEL_LEVEL = "4"
+CMAKE_CXX_COMPILER_LAUNCHER = "ccache"
+CCACHE_DIR = "/tmp/turboxl-ccache"
+CCACHE_MAXSIZE = "1G"
+CCACHE_BASEDIR = "/project"
+CCACHE_COMPILERCHECK = "content"
+CMAKE_ARGS = "-DTURBOXL_PORTABLE_BUILD=ON -DTURBOXL_ENABLE_NATIVE_OPTIMIZATION=OFF -DTURBOXL_ENABLE_IPO=ON"
+
+[tool.cibuildwheel.macos]
+before-all = "brew install ccache libxml2 minizip-ng zlib-ng"
+
+[tool.cibuildwheel.macos.environment]
+CMAKE_BUILD_PARALLEL_LEVEL = "4"
+CMAKE_CXX_COMPILER_LAUNCHER = "ccache"
+CCACHE_DIR = "/tmp/turboxl-ccache"
+CCACHE_MAXSIZE = "1G"
+CCACHE_BASEDIR = "$(pwd)"
+CCACHE_COMPILERCHECK = "content"
+MACOSX_DEPLOYMENT_TARGET = "12.0"
+PKG_CONFIG_PATH = "/opt/homebrew/opt/libxml2/lib/pkgconfig:/opt/homebrew/opt/minizip-ng/lib/pkgconfig:/opt/homebrew/opt/zlib-ng/lib/pkgconfig:/usr/local/opt/libxml2/lib/pkgconfig:/usr/local/opt/minizip-ng/lib/pkgconfig:/usr/local/opt/zlib-ng/lib/pkgconfig"
+CMAKE_PREFIX_PATH = "/opt/homebrew/opt/libxml2:/opt/homebrew/opt/minizip-ng:/opt/homebrew/opt/zlib-ng:/usr/local/opt/libxml2:/usr/local/opt/minizip-ng:/usr/local/opt/zlib-ng"
+CMAKE_ARGS = "-DTURBOXL_PORTABLE_BUILD=ON -DTURBOXL_ENABLE_NATIVE_OPTIMIZATION=OFF -DTURBOXL_ENABLE_IPO=ON"
+
 [tool.scikit-build.metadata.version]
 provider = "scikit_build_core.metadata.setuptools_scm"
 

--- a/tools/wheels/install_linux_deps.sh
+++ b/tools/wheels/install_linux_deps.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# manylinux_2_28 is AlmaLinux 8 based. Using its ABI-compatible development
+# packages avoids rebuilding the same small C libraries for every wheel run;
+# auditwheel vendors non-policy shared libraries into the finished wheel.
+dnf install -y --setopt=install_weak_deps=False epel-release
+dnf install -y --setopt=install_weak_deps=False \
+    ccache \
+    libxml2-devel \
+    minizip-devel \
+    zlib-devel
+dnf clean all

--- a/tools/wheels/smoke_test.py
+++ b/tools/wheels/smoke_test.py
@@ -1,0 +1,27 @@
+"""Minimal installed-wheel and architecture smoke test for cibuildwheel."""
+
+from __future__ import annotations
+
+import struct
+import sys
+
+import turboxl
+
+
+def main() -> None:
+    expected_bits = int(sys.argv[1]) if len(sys.argv) > 1 else None
+    actual_bits = struct.calcsize("P") * 8
+
+    if expected_bits is not None and actual_bits != expected_bits:
+        raise RuntimeError(
+            f"wheel architecture mismatch: expected {expected_bits}-bit Python, "
+            f"got {actual_bits}-bit"
+        )
+    if not callable(turboxl.read_sheet_to_csv):
+        raise RuntimeError("turboxl.read_sheet_to_csv is missing or not callable")
+
+    print(f"turboxl import OK on {actual_bits}-bit {sys.platform}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- replace the duplicated verify and release jobs with one reusable cibuildwheel workflow
- add CPython 3.10-3.12 Windows x86 wheels using an explicit 32-bit MSVC environment and vcpkg triplet
- replace Linux source builds of zlib and minizip with manylinux system packages
- centralize cibuildwheel policy, uv builds, ccache settings, and architecture-aware wheel smoke tests

## Validation
- actionlint passes for all workflow files
- cibuildwheel 4.1 selects cp310, cp311, and cp312 win32 identifiers
- isolated macOS wheel builds, installs, and passes the smoke test
- TOML, shell syntax, Python compilation, and git diff checks pass

## Note
The manylinux container could not be executed locally because Docker Desktop was not running; AlmaLinux 8 package and pkg-config availability was verified separately.