### PR TITLE
Release: prepare TurboXL 0.2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(turboxl LANGUAGES CXX)
+project(turboxl VERSION 0.2.0 LANGUAGES CXX)
 
 # Set C++ standard
 set(CMAKE_CXX_STANDARD 20)
@@ -456,7 +456,7 @@ install(EXPORT turboxlTargets
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
     "${CMAKE_CURRENT_BINARY_DIR}/turboxlConfigVersion.cmake"
-    VERSION 0.1.0
+    VERSION ${PROJECT_VERSION}
     COMPATIBILITY AnyNewerVersion
 )
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ python3 -m build -w
 
 Outputs go to `dist/`, for example:
 
-- `dist/turboxl-0.1.0-<python>-<abi>-<platform>.whl`
+- `dist/turboxl-0.2.0-<python>-<abi>-<platform>.whl`
 
 Install the built wheel locally:
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "turboxl"
-version = "0.1.0"
+version = "0.2.0"
 description = "Fast XLSX to CSV converter (C++ core with Python bindings)"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "turboxl",
-  "version-string": "0.1.44",
+  "version-string": "0.2.0",
   "builtin-baseline": "66c0373dc7fca549e5803087b9487edfe3aca0a1",
   "dependencies": [
     "libxml2",


### PR DESCRIPTION
## Summary
- bump CMake package metadata to 0.2.0
- align vcpkg and legacy Python metadata with 0.2.0
- update the documented wheel filename

## Validation
- configured the CMake package and verified `PACKAGE_VERSION` is 0.2.0
- built `turboxl-0.2.0-cp311-cp311-macosx_15_0_arm64.whl` locally
- installed the wheel in a clean Python 3.11 environment
- passed `tools/wheels/smoke_test.py 64`

## Publishing
After this PR is merged, push tag `v0.2.0` on the merge commit. The tag-triggered Release wheels workflow will build the Linux x86_64, Windows x64, Windows x86, macOS arm64, and macOS x86_64 wheel sets for CPython 3.10-3.12 and publish them to PyPI.